### PR TITLE
quay.io/haskell_works/stack-build-python:16.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/project
     docker:
-      - image: quay.io/haskell_works/stack-build-python
+      - image: quay.io/haskell_works/stack-build-python:16.04
 
     steps:
       - checkout


### PR DESCRIPTION
Use quay.io/haskell_works/stack-build-python:16.04 until we upgrade.