### PR TITLE
MAYH-8148 distinguish cache keys that only match as prefixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           keys:
                 - stack--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "resolver.version" }}--{{ checksum "package.yaml" }}--{{ checksum "stack.yaml" }}
                 - stack--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "resolver.version" }}--{{ checksum "package.yaml" }}
-                - stack--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "resolver.version" }}
+                - stack--{{ checksum "ghc.version" }}--{{ .Environment.CACHE_VERSION }}--{{ checksum "resolver.version" }}--
                 - stack--{{ checksum "ghc.version" }}--only
 
       - run: stack setup


### PR DESCRIPTION
There is no corresponding `save_cache` for this key. It matches one of the previous fully specified keys. Differentiate it with trailing dashes to make it a bit easier to see.